### PR TITLE
Fixed crash because of negative DropDown height issue in `RecipientEditTextView` class

### DIFF
--- a/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/src/com/android/ex/chips/RecipientEditTextView.java
@@ -664,8 +664,13 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
                     // bottom.
                     mDropdownAnchor.getLocationOnScreen(mCoords);
                     getWindowVisibleDisplayFrame(mRect);
-                    setDropDownHeight(mRect.bottom - mCoords[1] - mDropdownAnchor.getHeight() -
-                            getDropDownVerticalOffset());
+                    int bottom = mCoords[1] + getHeight();
+                    int availableHeightBelow = mRect.bottom - bottom;
+                    if (availableHeightBelow > 0) {
+                        setDropDownHeight(availableHeightBelow);
+                    } else {
+                        setDropDownHeight(250);
+                    }
                 }
 
                 mCurrentSuggestionCount = suggestionCount;

--- a/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/src/com/android/ex/chips/RecipientEditTextView.java
@@ -664,14 +664,8 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
                     // bottom.
                     mDropdownAnchor.getLocationOnScreen(mCoords);
                     getWindowVisibleDisplayFrame(mRect);
-                    int bottom = mCoords[1] + getHeight();
-                    int availableHeightBelow = mRect.bottom - bottom;
-                    if (availableHeightBelow > 0) {
-                        setDropDownHeight(availableHeightBelow);
-                    } else if (entries != null){
+                    if (entries != null) {
                         setDropDownHeight(entries.size() * (int) getContext().getResources().getDimension(R.dimen.chip_dropdown_height));
-                    } else {
-                        setDropDownHeight(mCoords[1]);
                     }
                 }
 

--- a/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/src/com/android/ex/chips/RecipientEditTextView.java
@@ -669,7 +669,7 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
                     if (availableHeightBelow > 0) {
                         setDropDownHeight(availableHeightBelow);
                     } else {
-                        setDropDownHeight(250);
+                        setDropDownHeight(mCoords[1]);
                     }
                 }
 

--- a/src/com/android/ex/chips/RecipientEditTextView.java
+++ b/src/com/android/ex/chips/RecipientEditTextView.java
@@ -668,6 +668,8 @@ public class RecipientEditTextView extends MultiAutoCompleteTextView implements
                     int availableHeightBelow = mRect.bottom - bottom;
                     if (availableHeightBelow > 0) {
                         setDropDownHeight(availableHeightBelow);
+                    } else if (entries != null){
+                        setDropDownHeight(entries.size() * (int) getContext().getResources().getDimension(R.dimen.chip_dropdown_height));
                     } else {
                         setDropDownHeight(mCoords[1]);
                     }


### PR DESCRIPTION
Description:
The app is crashing in the Edit Event Screen while adding guest email id.

Reason:
While typing the email the negative values is getting set in `RecipientEditTextView` class for `setDropDownHeight()` method & hence app was crashing for Android API level 27+ devices.

Exception: 
IllegalArgumentException: "Invalid height. Must be a positive value, MATCH_PARENT, or WRAP_CONTENT.

#### The crash fix is tested on: Android OnePlus(API level 30) & Android MotoG4+(API level 25)

Reported Issue:
https://github.com/Etar-Group/Etar-Calendar/issues/981

Screen recording:
https://user-images.githubusercontent.com/20037228/131183077-b880b78b-9aa1-473a-ae80-4f11c098daa5.mp4

Thank you!